### PR TITLE
Define EB legacy CIDRs by environment and subnet (public/private).

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ See [documentation](https://confluence.evbhome.com/display/SRE/Install+Terraform
 | database\_multi\_az | boolean indicating whether to run multi-az RDS | `string` | `"false"` | no |
 | database\_storage | allocated storage for RDS database | `string` | `"10"` | no |
 | db\_subnet\_ids | Subnet IDs of DB subnets in VPC | `any` | n/a | yes |
-| eb\_priv\_cidrs | CIDRs blocks of EB legacy account private subnets | `any` | n/a | yes |
+| eb\_prod\_priv\_cidrs | CIDRs blocks of EB legacy account prod private subnets | `any` | n/a | yes |
+| eb\_prod\_pub\_cidrs | CIDRs blocks of EB legacy account prod public subnets | `any` | n/a | yes |
+| eb\_qa\_priv\_cidrs | CIDRs blocks of EB legacy account QA private subnets | `any` | n/a | yes |
+| eb\_stage\_priv\_cidrs | CIDRs blocks of EB legacy account stage private subnets | `any` | n/a | yes |
 | enable\_metrics\_collection | whether PTFE's internal metrics collection should be enabled | `string` | `"true"` | no |
 | enc\_password | Set the encryption password for the install | `any` | n/a | yes |
 | extra\_no\_proxy | a comma separated list of hosts to exclude from proxying | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "aws_security_group" "ptfe" {
     protocol    = "tcp"
     from_port   = 53
     to_port     = 53
-    cidr_blocks = split(",", var.eb_priv_cidrs)
+    cidr_blocks = split(",", var.eb_prod_pub_cidrs)
   }
 
   # Connect to eb ops-dir
@@ -51,15 +51,31 @@ resource "aws_security_group" "ptfe" {
     protocol    = "udp"
     from_port   = 53
     to_port     = 53
-    cidr_blocks = split(",", var.eb_priv_cidrs)
+    cidr_blocks = split(",", var.eb_prod_pub_cidrs)
   }
 
-  # Connect to Consul on eb qa/stage/prod
+  # Connect to Consul on eb prod
   egress {
     protocol    = "tcp"
     from_port   = 8500
     to_port     = 8500
-    cidr_blocks = split(",", var.eb_priv_cidrs)
+    cidr_blocks = split(",", var.eb_prod_priv_cidrs)
+  }
+
+  # Connect to Consul on eb stage
+  egress {
+    protocol    = "tcp"
+    from_port   = 8500
+    to_port     = 8500
+    cidr_blocks = split(",", var.eb_stage_priv_cidrs)
+  }
+
+  # Connect to Consul on eb qa
+  egress {
+    protocol    = "tcp"
+    from_port   = 8500
+    to_port     = 8500
+    cidr_blocks = split(",", var.eb_qa_priv_cidrs)
   }
 
   egress {

--- a/terraform.tfvars.tmpl
+++ b/terraform.tfvars.tmpl
@@ -45,4 +45,7 @@ initial_admin_password    = "fillme"
 initial_org_name          = "fillme"
 initial_org_email         = "fillme"
 # EB legacy account connectivity
-eb_priv_cidrs = "fillme"
+eb_prod_pub_cidrs   = "fillme"
+eb_prod_priv_cidrs  = "fillme"
+eb_stage_priv_cidrs = "fillme"
+eb_qa_priv_cidrs    = "fillme"

--- a/variables.tf
+++ b/variables.tf
@@ -319,6 +319,18 @@ variable "initial_org_email" {
   description = "email of initial organization in PTFE"
 }
 
-variable "eb_priv_cidrs" {
-  description = "CIDRs blocks of EB legacy account private subnets"
+variable "eb_prod_pub_cidrs" {
+  description = "CIDRs blocks of EB legacy account prod public subnets"
+}
+
+variable "eb_prod_priv_cidrs" {
+  description = "CIDRs blocks of EB legacy account prod private subnets"
+}
+
+variable "eb_stage_priv_cidrs" {
+  description = "CIDRs blocks of EB legacy account stage private subnets"
+}
+
+variable "eb_qa_priv_cidrs" {
+  description = "CIDRs blocks of EB legacy account QA private subnets"
 }


### PR DESCRIPTION
In this way we can have a more fine-grained control of SG rules,
specifically:
- outbound rule to prod pub subnets for dns
- outbound rules to qa/stage/prod priv subnets for consul